### PR TITLE
Rewrite to emphasize standardization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,124 +1,125 @@
-# Permafills
-Shipping high-level features as self-hosted JS imports
+# Layered APIs
+
+A new standards effort for collaborating on high-level features.
 
 ## Problem
-The [Extensible Web Manifesto](https://extensiblewebmanifesto.org/)’s focus on low-level primitives promotes a healthy, well-layered platform that encourages innovation and experimentation in JavaScript. But focusing on low-level primitives means that developers must build most application-level components on their own, creating a high barrier to entry for new web developers. 
+
+The [Extensible Web Manifesto](https://extensiblewebmanifesto.org/)’s focus on low-level primitives promotes a healthy, well-layered platform that encourages innovation and experimentation in JavaScript. But focusing on low-level primitives means that developers must build most application-level components on their own, creating a high barrier to entry for new web developers.
 
 This lack of built-in high-level features also bloats page load size. The average site payload is [2.5 MB and takes 19 seconds to load](https://www.doubleclickbygoogle.com/articles/mobile-speed-matters/).
 
-However, shipping high-level features carries its own risks. Standardizing and building the right API becomes exponentially harder as the complexity of a feature increases. The web has a long history of magic features that don't solve the right use cases. When we get something wrong with a high-level feature, developers are often left with no other way to achieve their goals, so they contort the feature in harmful ways to make it work.
+Historically, standards bodies and implementers have been reluctant to work on higher-level APIs. In particular, introducing new capabilities via high-level APIs is dangerous, as when we get something wrong, developers are often left with no other way to access these capabilities. Shipping features also incurs an ongoing maintenance and runtime cost — every new feature pollutes the browser namespace, increases JS startup costs, and represents a new surface to introduce bugs throughout the codebase.
 
-Shipping features also incurs an ongoing maintenance and runtime cost — every new feature pollutes the browser namespace, increases JS startup costs, and represents a new surface to introduce bugs throughout the codebase.
+Additionally, the incentive for web developers to adopt higher-level APIs is low due to uneven browser uptake. If a feature does not add some essential new capability, but instead makes your application easier to write in newish browsers, it's rarely seen as worthwhile to go through the feature-detection dance if you have to write the fallback code anyway. Instead, developers often just use libraries built on top of the widely-supported lower-level APIs, incurring the attendant costs on all of their users.
 
 ## Goal
-Enable browsers to ship high-level features such that:
 
-- Runtime/maintenance cost scales
-- Experimentation with real world websites is possible before shipping
-- Developers are able to build their own version of a high-level feature if ours does not meet their use cases
+Enable the creation of high-level features such that:
+
+- They stay layered on top of low-level features, never getting access to new capabilities unavailable to web developers
+- Runtime costs for web developers using the features scale
+- Maintenance costs for standardizing and implementing the features scale
+- Fallback to polyfills, for browsers that do not support the features, is easy and transparent
 
 ## Solution
-Implement high-level features as unprivileged JavaScript modules, and bundle those libraries with browsers. In all other respects, these features would be like normal web APIs: 
 
-- Follow the normal cross-browser standardization process
-- Version with the browser
+### Part 1: the infrastructure
 
-There are several options to expose these modules to developers:
+We propose a new syntax for accessing certain web platform features, known as _layered APIs_, by importing them from special URLs:
 
-```javascript
-<script type="module" 
-        stdsrc="browser:infinite-list"                // Browser provided script
-        src="https://some.cdn.com/infinite-list.js">  // Fallback for older browsers
+```html
+<script type="module"
+        src="std:infinite-list|https://some.cdn.com/infinite-list.js">
+</script>
+
+<infinite-list>...</infinite-list>
+```
+
+```html
+<script type="module">
+import { get, set } from "std:async-local-storage|https://other.cdn.com/async-local-storage.js";
+
+get("key").then(...);
 </script>
 ```
 
-This allows developers to provide a 3rd party library fallback for browsers that have not bundled the feature. Another way to accomplish this could be:
+As shown here, this `std:x|y` URL syntax contains both an _API identifier_ (e.g. "`infinite-list`" or "`async-local-storage`"), and a _fallback URL_. If the browser does not support the layered API specified by the given API identifier, it instead loads the contents of the fallback URL.
 
-```javascript
-<script type="module" 
-        src="browser:infinite-list|https://cdn.example.com/infinite-list.js">
-</script>
-```
+### Part 2: the standards process
 
-This would require no new syntax and could be handled under-the-hood by browser implementations.
+Like all web platform features, layered APIs would go through the standards process, producing specifications for their API surface and behavior. However, they would have an important additional constraint: their specifications _must not_ use any "magic" that is inaccessible to web developers. A concrete way of stating this is that a web developer must be able to implement a given layered API's specification, purely in unprivileged JavaScript.
 
-Finally, there is a question as to whether we need explicit import at all. We could pursue ways to identify features that are used on the page and automatically import them. Perhaps through a manifest of some sort.
+Apart from this additional requirement, layered APIs would be standardized in the same way as other APIs: incubation and explainers; transition to a standards body; TAG review; etc.
 
-## Benefits to web developers
+## Benefits for web developers
 
 ### Cheaper high-level features
 
-Permafills will reduce the amount of script developers need to load over the network. 
+Layered APIs will reduce the amount of script developers need to load over the network.
 
-Also, because developers explicitly import the features they use, we don’t bloat the global context of the platform for everyone. You only pay the cost of a feature (including increased JS context start time) for features that you use.
+Also, because developers explicitly import the features they use, we don’t bloat the global context of the platform for everyone. You only pay the cost of a feature for features that you use. Because of the requirement to import, implementations can use a variety of implementation strategies, ranging from business-as-usual to lazily-loading the feature from their own servers on every use.
 
 ### Encourage layering
 
-By implementing permafills as unprivileged JavaScript, we are forced to identify and ship the appropriate low-level primitives needed to build the high-level feature. This gives web developers the tools they need to build their own applications and libraries.
-
-### Hackable
-
-Because permafills are maintained in the open and written in JavaScript, developers can more easily contribute to them. We'd maintain the same high bar we do for contributions to a web standard, but the turnaround time for developers getting their feature requests (or bug fixes!) into the versions shipping with browsers could be shorter.
+By requiring that layered APIs not use any unexposed primitives, we are forced to identify and ship the appropriate low-level primitives needed to build the high-level feature. This gives web developers the tools they need to build their own applications and libraries. And new capabilities are never locked up inside of a higher-level API.
 
 ### Built-in fallback
 
-Permafills are instantly usable in all browsers via the built-in fallback to non-permafill polyfill code.
+Layered APIs are instantly usable in all browsers via the built-in fallback to polyfill code. At the same time, newer browser versions that do include the feature will not be shipped unnecessary code, thus decreasing page size and JavaScript parsing time.
 
-## Benefits to browser implementers
+## Benefits for standardization and implementation
 
 ### Healthier platform implementation
 
-Implementing in JavaScript provides a clean implementation boundary. Changing a JavaScript library can't create thorny bugs throughout the renderer.
-
-### Code sharing
-
-Permafill code will be shared between browsers, making interop trivial.
-
-Code sharing also allows browsers to pursue different priorities and features, while benefiting from the various directions and investments of other browsers.
+Requiring that layered APIs sit on top of the platform's primitives provides a clean implementation boundary. Changing a layered API can't create thorny bugs throughout other specifications or parts of the implementation.
 
 ### Decreased maintenance overhead
 
-Implementers often shy away from building high-level features since they can create large, ongoing technical debt. Permafills can reduce this risk. Browsers can stop bundling a given permafill and just maintain a browser: URL-to-CDN-URL mapping instead.
+Implementers often shy away from building high-level features since they can create large, ongoing technical debt. Layered APIs can reduce this risk. Browsers can stop bundling a given layered and just maintain a API-dentifier-to-CDN-URL mapping instead, that lazily loads the API as a JavaScript library.
+
+### Security and privacy
+
+Layered APIs will have an easier time with security and privacy review, since they build on top of other APIs which have already passed security and privacy review. By definition, they are unable to do anything that web developers can't already do themselves, which sets an upper bound on the amount of harm possible.
 
 ## Caveats
-We believe that the restriction of using unprivileged JavaScript, and the benefits that come from this, is necessary in order for the web to responsibly ship high-level features. However, this restriction has its tradeoffs:
+
+We believe that the layering restriction, and the benefits that come from it, is necessary in order for the web to responsibly ship high-level features. However, this restriction has its tradeoffs:
 
 - Privacy and security sensitive features could not be implemented using this method
-- Developers or libraries that modify the prototypes of primitives could break permafills
-- Features that require new low-level primitives would be blocked on those primitives shipping
+- Features that require new low-level primitives would be blocked on those primitives being standardized and shipped first
 
 ## FAQ
-__Will we ship existing libraries as permafills?__
 
-We believe that existing libraries won’t be a good fit for permafills because permafills will need to version with the browser, be backwards-compatible, and owned by the browsers bundling the code.
+__Will we ship existing libraries as layered APIs?__
 
-Versioning allows traditional libraries to move forward at an aggressive pace, responding to changes in the platform and differentiating themselves within the evolving competitive landscape. However, version skew means that very few sites are using the same set of code for a library. In contrast, with permafills — like all other web platform features — you don't get to choose what version you use; you instead get the one implemented in the current browser version.
+We believe that existing libraries won't be a good fit for layered APIs because they haven't been through the standardization process. Instead, they are maintained by a small team with a different priority of constituencies.
+
+Additionally, like all web platform features, layered APIs will need to version with the browser, be backwards-compatible, and have their code owned by the browsers shipping it.
+
+The lack of standardization, coupled with the ability to version, allows traditional libraries to move forward at an aggressive pace, responding to changes in the platform and differentiating themselves within the evolving competitive landscape. However, version skew means that very few sites are using the same set of code for a library. In contrast, with layered APIs — like all other web platform features — you don't get to choose what version you use; you instead get the one implemented in the browser you're running.
 
 Given that they have discrete versions, libraries don't maintain backwards compatibility to the level of web platform features. Much of what allows libraries to present elegant developer experiences is their ability to make a clean break from past versions and build a focused product.
 
-In order for any browser to be comfortable with bundling a piece of code, they must have some final say over changes made that land in the browser (e.g. via code review). External parties will still be heavily involved in the permafills process, but libraries are unlikely to cede this final say to browsers.
+In order for any browser to be comfortable with bundling a piece of code, they must have some final say over changes made that land in the browser, traditionally via the standards process. External parties will still be heavily involved in the layered APIs standardization, but libraries are unlikely to cede this final say to standards bodies.
 
-Finally, we do not want to pick winners in the ecosystem. While many libraries have a large usage base, they always have competitors. We want to permafill features that represent repeated — not competing — work.
+Finally, we do not want to pick winners in the ecosystem. While many libraries have a large usage base, they always have competitors. We want to standardize features that represent repeated — not competing — work.
 
-These requirements do not preclude an external library from becoming a permafill. They only make it unlikely. If a library is:
+These requirements do not preclude an external library from becoming a layered API. They only make it unlikely. If a library is:
 
 - High usage
-- Agreed amongst browsers and developers to be a canonical implementation
-- Versionless (i.e. version with the browser)
-- Committed to backwards compatibility 
-- Willing to cede final code approval to browsers 
+- Agreed amongst the web platform community to be a canonical implementation
+- Versionless
+- Committed to backwards compatibility
+- Willing to cede governance to the standards process
 
-… then they may be viable candidates for a permafill. 
+… then it may be viable candidate for becoming a layered API.
 
 __Why not just use libraries on CDNs?__
 
-A common question is how permafills differ from CDNs and aggressive caching. While these two ideas are very similar, a few advantages come from shipping directly with a browser.
+A common question is how layered APIs differ from placing JavaScript libraries on CDNs and implementing some sort of aggressive caching. While these two ideas are very similar, a CDN-based standard library neglects the role of the standards process in collaborating on web platform features. Additionally, a few advantages come from shipping directly with a browser.
 
 Most obviously, shipping with the browser avoids any network cost on page load, whereas a CDN only reduces the cost. In emerging markets, where even a single RTT can be on the order of seconds, this benefit is significant. While aggressive caching could solve this problem for future requests, the cost must still be paid at least once.
 
-Shipping libraries directly with the browser also means they can be more streamlined than a generic library. We can store parsed code, reducing bootup cost by hundreds of milliseconds for large JS features. We can also strip out unnecessary feature detects or polyfills that aren’t needed for that particular browser version.
+Shipping libraries directly with the browser also means they can be more streamlined than a generic library. Traditionally this is done by implementing features in C++, although alternate strategies (such as Rust, or pre-snapshotted JavaScript) are possible. This can reduce bootup cost by hundreds of milliseconds for large features. Similarly, by being part of the browser codebase, layered APIs don't need to include unnecessary feature detects or polyfills.
 
-Another major difference is that because permafills are browser features, they go through the same collaborative cross-browser design process. Falling back to proprietary CDNs would make it more difficult to maintain this open design process.
-
-Finally, "permafills vs. CDNs" is a somewhat misleading framing. Under the hood, permafills could even be implemented as cross-browser, collaboratively-developed libraries that are lazily loaded by the browser from CDNs. Indeed, for rarely-used permafills, this may be more appropriate than bundling them with the initial download. In that case, the delta between permafills and a CDN-based solution is their commitment to a transparent, stable development process and the commitment to first class support within browsers.
-
+Finally, "layered APIs vs. CDNs" is a somewhat misleading framing. Under the hood, layered APIs could even be implemented as cross-browser, standards-process-governed libraries that are lazily loaded by the browser from CDNs. Indeed, for rarely-used layered APIs, this may even be an attractive implementation strategy. In that case, the delta between layered APIs and a CDN-based solution is their commitment to a transparent, standards-based development process that produces specifications, and the commitment to first class support within browsers.


### PR DESCRIPTION
The majority of the changes here are "non-normative", and simply a matter of more clearly emphasizing the way in which the process works. It shifts the focus away from the implementation detail of code sharing, toward the fact that these would, like all web platform APIs, be created through the standards process. In doing this, it refocuses our goals and the benefits involved.

Notably, this renames the proposal from "permafills" to "layered APIs", as "permafills" was giving misleading impressions. We may want to rename the repository as well.

At the same time, this fleshes out some of the examples, also switching from browser:x|y to std:x|y, and removing the stdsrc="" proposal.